### PR TITLE
parameterizing the port option for rhel 7 family. If the option is not

### DIFF
--- a/authconfig/common.sls
+++ b/authconfig/common.sls
@@ -18,12 +18,14 @@ copy_sssd_conf:
     - watch_in:
       - service: sssd_service
 
+{% if authconfig.ldap_authtok %}
 hash_authconfig_bind_pass:
   cmd.run:
     - name: echo -n {{ authconfig.sssd_pass }} | sss_obfuscate -s -d {{ authconfig.domain }}
     - env:
       - PYTHONPATH: ${PYTHONPATH}:/usr/lib64/python2.7/site-packages
     - shell: {{ grains.shell if 'shell' in grains else '/bin/bash' }}
+{% endif %}
 
 sssd_service:
   service.running:

--- a/authconfig/defaults.yaml
+++ b/authconfig/defaults.yaml
@@ -7,7 +7,7 @@ authconfig:
   domain: {{ salt['pillar.get']('authconfig.domain') }}
   krb_dc_host: {{ salt['pillar.get']('authconfig.krb_dc_host') }}
   krb_dc_port: {{ salt['pillar.get']('authconfig.krb_dc_port') }}
-  ldap_schema:
+  ldap_schema: # Four schema types are currently supported: rfc2307,rfc2307bis,IPA,AD (default rfc2307)
   ldap_authtok:
   ldap_tls:
   opts: []

--- a/authconfig/defaults.yaml
+++ b/authconfig/defaults.yaml
@@ -6,6 +6,7 @@ authconfig:
   debug_mode: False
   domain: {{ salt['pillar.get']('authconfig.domain') }}
   krb_dc_host: {{ salt['pillar.get']('authconfig.krb_dc_host') }}
+  krb_dc_port: {{ salt['pillar.get']('authconfig.krb_dc_port') }}
   opts: []
   realm: {{ salt['pillar.get']('authconfig.realm') }}
   uniquemember: 'map    group  uniqueMember     member'

--- a/authconfig/defaults.yaml
+++ b/authconfig/defaults.yaml
@@ -7,6 +7,9 @@ authconfig:
   domain: {{ salt['pillar.get']('authconfig.domain') }}
   krb_dc_host: {{ salt['pillar.get']('authconfig.krb_dc_host') }}
   krb_dc_port: {{ salt['pillar.get']('authconfig.krb_dc_port') }}
+  ldap_schema:
+  ldap_authtok:
+  ldap_tls:
   opts: []
   realm: {{ salt['pillar.get']('authconfig.realm') }}
   uniquemember: 'map    group  uniqueMember     member'

--- a/authconfig/files/sssd.conf
+++ b/authconfig/files/sssd.conf
@@ -28,18 +28,29 @@ debug_level = 3
 {% if authconfig.debug_mode %}
 debug_level = 3
 {% endif %}
+access_provider = ldap
+ldap_access_order = host
+ldap_user_authorized_host = host
 id_provider = ldap
 ldap_uri = {% for s in authconfig.servers %}ldap://{{s}}/{% if not loop.last %},{% endif %}{% endfor %}
 
+{% if authconfig.ldap_schema %}
 ldap_schema = AD
+{% endif %}
 ldap_search_base = {{ authconfig.basedn }}
 ldap_default_bind_dn = {{ authconfig.bind_user }}
+{% if authconfig.ldap_authtok %}
 ldap_default_authtok_type = obfuscated_password
 ldap_default_authtok = {{ authconfig.sssd_pass }}
+{% endif %}
+{% if authoconfig.ldap_tls %}
 ldap_id_use_start_tls = true
 ldap_tls_reqcert = allow
+{% endif %}
 
 auth_provider = krb5
-krb5_realm = {{ authconfig.realm }}
 krb5_server = {{ authconfig.servers |join(',')}}
+krb5_realm = {{ authconfig.realm }}
 cache_credentials = true
+enumerate = false
+min_id = 1

--- a/authconfig/files/sssd.conf
+++ b/authconfig/files/sssd.conf
@@ -35,7 +35,7 @@ id_provider = ldap
 ldap_uri = {% for s in authconfig.servers %}ldap://{{s}}/{% if not loop.last %},{% endif %}{% endfor %}
 
 {% if authconfig.ldap_schema %}
-ldap_schema = AD
+ldap_schema = {{ authconfig.ldap_schema }}
 {% endif %}
 ldap_search_base = {{ authconfig.basedn }}
 ldap_default_bind_dn = {{ authconfig.bind_user }}

--- a/authconfig/krbdchost.sls
+++ b/authconfig/krbdchost.sls
@@ -2,7 +2,7 @@
 
 {% if grains['os_family'] == 'RedHat'  %}
   {% set url = salt['grains.filter_by']({
-    '7': authconfig.get('authconfig:krb_dc_host', '{0}:{1}'.format(authconfig.krb_dc_host, authconfig.krb_dc_port),
+    '7': authconfig.get('authconfig:krb_dc_host', '{0}:{1}'.format(authconfig.krb_dc_host, authconfig.krb_dc_port)),
     '6': authconfig.get('authconfig:krb_dc_host)'),
   }, grain='osmajorrelease', default='7' )
   %}

--- a/authconfig/krbdchost.sls
+++ b/authconfig/krbdchost.sls
@@ -2,7 +2,7 @@
 
 {% if grains['os_family'] == 'RedHat'  %}
   {% set url = salt['grains.filter_by']({
-    '7': authconfig.get('authconfig:krb_dc_host', '{0}:{1}'.format(authconfig.krb_dc_host, 88)),
+    '7': authconfig.get('authconfig:krb_dc_host', '{0}:{1}'.format(authconfig.krb_dc_host, authconfig.krb_dc_port),
     '6': authconfig.get('authconfig:krb_dc_host)'),
   }, grain='osmajorrelease', default='7' )
   %}

--- a/authconfig/tests/pillar/authconfig/init.sls
+++ b/authconfig/tests/pillar/authconfig/init.sls
@@ -4,6 +4,7 @@ authconfig:
   computer_ou: something
   domain: somedomain.net
   krb_dc_host: globalad.corp.somedomain.net
+  krb_dc_port: 88
   realm: ad.somedomain.net
   servers:
     - ad.somedomain.net


### PR DESCRIPTION
needed just set the port to the standard kerberos.